### PR TITLE
Feature/003 Syscall and C void pointer

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -141,6 +141,13 @@ type function_decl = {
   body: kbody;
 }
 
+type syscall_decl = {
+  syscall_name: string;
+  parameters: (string * ktype) list;
+  return_type: ktype;
+  opcode: int64
+}
+
 type external_func_decl = {
   sig_name: string;
   fn_parameters: ktype list;
@@ -165,6 +172,7 @@ type sig_decl = {
 type module_node = 
 | NExternFunc of external_func_decl
 | NFunction of function_decl
+| NSyscall of syscall_decl
 | NSigFun of sig_decl
 | NStruct of struct_decl
 | NEnum of enum_decl

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -350,6 +350,7 @@ module Type = struct
         n1 = n2 && mp1 = mp2 && (pt1 |> Util.are_same_lenght pt2) && (List.for_all2 are_compatible_type pt1 pt2)
     | TUnknow, _ | _ , TUnknow -> true
     | TPointer _, TPointer TUnknow -> true
+    | TPointer TUnknow, TPointer _ -> true
     | _, _ -> lhs =  rhs
 
   let rec remap_generic_ktype (generics_table) (ktype) = 

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -143,7 +143,7 @@ type function_decl = {
 
 type syscall_decl = {
   syscall_name: string;
-  parameters: (string * ktype) list;
+  parameters: ktype list;
   return_type: ktype;
   opcode: int64
 }
@@ -267,6 +267,7 @@ module Error = struct
   | Unmatched_Parameters_length of { expected: int; found: int }
   | Unmatched_Generics_Resolver_length of { expected: int; found: int }
   | Uncompatible_type_for_C_Function of { external_func_decl: external_func_decl }
+  | Uncompatible_type_for_Syscall of { syscall_decl: syscall_decl}
   | Mismatched_Parameters_Type of { expected : ktype; found : ktype }
   | Unknow_Function_Error
 
@@ -400,12 +401,13 @@ module Function_Decl = struct
   type t = 
   | Decl_External of external_func_decl
   | Decl_Kosu_Function of function_decl
+  | Decl_Syscall of syscall_decl
 
   let decl_external e = Decl_External e
   let decl_kosu_function e = Decl_Kosu_Function e
-
+  let decl_syscall e = Decl_Syscall e
   let is_external = function Decl_External _ -> true | _ -> false
-
+  let is_syscall = function Decl_Syscall _ -> true | _ -> false
   let is_kosu_func = function Decl_Kosu_Function _ -> true | _ -> false
 end
 

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -8,9 +8,9 @@
     exception Unclosed_string
     exception Unclosed_comment
 
-    let keywords = Hashtbl.create 17
+    let keywords = Hashtbl.create 19
     let _ = ["cases", CASES; "const", CONST; "enum", ENUM; "external", EXTERNAL; "empty", EMPTY; "sig", SIG; "discard", DISCARD ; "else", ELSE; "fn", FUNCTION; 
-    "for", FOR; "false", FALSE; "nullptr", NULLPTR ;"struct", STRUCT; "of", OF; "true", TRUE; "switch", SWITCH; "sizeof", SIZEOF; "if", IF; 
+    "for", FOR; "false", FALSE; "nullptr", NULLPTR ;"struct", STRUCT; "syscall", SYSCALL ;"of", OF; "true", TRUE; "switch", SWITCH; "sizeof", SIZEOF; "if", IF; 
      "var", VAR; 
     ] |> List.iter (fun (s,t) -> Hashtbl.add keywords s t)
 }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -338,6 +338,7 @@ ctype:
         | "unit" -> TUnit
         | "bool" -> TBool
         | "stringl" -> TString_lit
+        | "anyptr" -> TPointer (TUnknow)
         | "s8" -> TInteger( Signed, I8)
         | "u8" -> TInteger( Unsigned, I8)
         | "s16" -> TInteger( Signed, I16)

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -142,7 +142,7 @@ statement:
 ;;
 
 syscall_decl:
-    | SYSCALL syscall_name=IDENT parameters=delimited(LPARENT, separated_list(COMMA, id=IDENT COLON ct=ctype { id, ct  }), RPARENT ) return_type=ctype 
+    | SYSCALL syscall_name=IDENT parameters=delimited(LPARENT, separated_list(COMMA, ct=ctype { ct  }), RPARENT ) return_type=ctype 
        LBRACE SYSCALL LPARENT opcode=Integer_lit RPARENT RBRACE {
         let _, _, value = opcode in
         {

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -11,7 +11,7 @@
 %token <string> Module_IDENT 
 %token LPARENT RPARENT LBRACE RBRACE LSQBRACE RSQBRACE WILDCARD
 %token SEMICOLON ARROWFUNC MINUSUP
-%token ENUM EXTERNAL SIG FUNCTION STRUCT TRUE FALSE EMPTY SWITCH IF ELSE FOR CONST VAR OF CASES DISCARD NULLPTR
+%token ENUM EXTERNAL SIG FUNCTION STRUCT TRUE FALSE EMPTY SWITCH IF ELSE FOR CONST VAR OF CASES DISCARD NULLPTR SYSCALL
 %token TRIPLEDOT
 %token COMMA
 %token PIPESUP
@@ -68,6 +68,7 @@ module_nodes:
     | enum_decl { NEnum $1 }
     | struct_decl { NStruct $1 }
     | external_func_decl { NExternFunc $1 }
+    | syscall_decl { NSyscall $1 }
     | function_decl { NFunction $1 }
     | sig_decl { NSigFun $1 }
     | const_decl { NConst $1 }
@@ -140,6 +141,17 @@ statement:
     | DISCARD expr SEMICOLON { SDiscard $2 }
 ;;
 
+syscall_decl:
+    | SYSCALL syscall_name=IDENT parameters=delimited(LPARENT, separated_list(COMMA, id=IDENT COLON ct=ctype { id, ct  }), RPARENT ) return_type=ctype 
+       LBRACE SYSCALL LPARENT opcode=Integer_lit RPARENT RBRACE {
+        let _, _, value = opcode in
+        {
+            syscall_name;
+            parameters;
+            return_type;
+            opcode = value
+        }
+    }
 
 function_decl:
     | FUNCTION name=IDENT generics_opt=option(d=delimited(INF, separated_nonempty_list(COMMA, id=IDENT {id}), SUP ) { d })

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -209,12 +209,6 @@ and typeof ?(generics_resolver = None) (env: Env.t) (current_mod_name: string) (
       |> List.iter (fun ((_, para_type), init_type)  -> if e |> Asthelper.Function.is_type_compatible_hashgen hashtal init_type para_type |> not then Mismatched_Parameters_Type { expected = para_type; found = init_type}  |> func_error |> raise);
 
       Asthelper.Function.to_return_ktype_hashtab hashtal e
-(*       
-      let combine_generics = List.combine e.generics (grc |> Option.value ~default:[]) in
-      let hashtal = Hashtbl.create (combine_generics |> List.length) in
-      combine_generics |> List.iter ( fun ( name, assoc ) -> Hashtbl.add hashtal name assoc);
-
-      typeof_kbody ~generics_resolver: (Some hashtal) (Env.create_env (e.parameters |> List.map (fun (name, ktype) -> (name, ({ is_const = true; ktype}: Env.variable_info ) )))) current_mod_name prog e.body *)
     )
     | Ast.Function_Decl.Decl_External external_func_decl -> begin
       if external_func_decl.is_variadic then 
@@ -248,6 +242,20 @@ and typeof ?(generics_resolver = None) (env: Env.t) (current_mod_name: string) (
             )) then external_func_decl.r_type
               else Unknow_Function_Error |> func_error |> raise
         end
+      | Ast.Function_Decl.Decl_Syscall syscall_decl -> (
+        match (Util.are_same_lenght syscall_decl.parameters parameters) with
+        | false -> Unmatched_Parameters_length { expected = syscall_decl.parameters |> List.length; found = parameters |> List.length } |> func_error |> raise
+        | true -> 
+          let mapped_type = parameters |> List.map ( typeof ~generics_resolver env current_mod_name prog ) in
+          let zipped = List.combine syscall_decl.parameters mapped_type in
+          if (zipped |> List.for_all (fun (para_type, init_type) -> 
+              match Asthelper.Program.is_c_type_from_ktype current_mod_name para_type prog, Asthelper.Program.is_c_type_from_ktype current_mod_name init_type prog with
+              | true, true -> 
+                if para_type <> init_type then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
+              | _ -> Ast.Error.Uncompatible_type_for_Syscall { syscall_decl } |> func_error |> raise
+            )) then syscall_decl.return_type
+              else Unknow_Function_Error |> func_error |> raise
+      )
       end
     | EBin_op (BAdd (lhs, rhs)) -> (
       let l_type = typeof env current_mod_name prog lhs in

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -224,7 +224,7 @@ and typeof ?(generics_resolver = None) (env: Env.t) (current_mod_name: string) (
       |> (List.for_all (fun (para_type, init_type) -> 
         match Asthelper.Program.is_c_type_from_ktype current_mod_name para_type prog, Asthelper.Program.is_c_type_from_ktype current_mod_name init_type prog with
         | true, true -> 
-          if para_type <> init_type then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
+          if not (Ast.Type.are_compatible_type para_type init_type) then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
         | _ -> Ast.Error.Uncompatible_type_for_C_Function { external_func_decl } |> func_error |> raise
       ) )
       |> fun b -> (if b then external_func_decl.r_type else Unknow_Function_Error |> func_error |> raise)
@@ -237,7 +237,7 @@ and typeof ?(generics_resolver = None) (env: Env.t) (current_mod_name: string) (
           if (zipped |> List.for_all (fun (para_type, init_type) -> 
               match Asthelper.Program.is_c_type_from_ktype current_mod_name para_type prog, Asthelper.Program.is_c_type_from_ktype current_mod_name init_type prog with
               | true, true -> 
-                if para_type <> init_type then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
+                if not (Ast.Type.are_compatible_type para_type init_type) then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
               | _ -> Ast.Error.Uncompatible_type_for_C_Function { external_func_decl } |> func_error |> raise
             )) then external_func_decl.r_type
               else Unknow_Function_Error |> func_error |> raise
@@ -251,7 +251,7 @@ and typeof ?(generics_resolver = None) (env: Env.t) (current_mod_name: string) (
           if (zipped |> List.for_all (fun (para_type, init_type) -> 
               match Asthelper.Program.is_c_type_from_ktype current_mod_name para_type prog, Asthelper.Program.is_c_type_from_ktype current_mod_name init_type prog with
               | true, true -> 
-                if para_type <> init_type then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
+                if not (Ast.Type.are_compatible_type para_type init_type) then Uncompatible_type_Assign { expected = para_type; found = init_type } |> stmt_error |> raise else true
               | _ -> Ast.Error.Uncompatible_type_for_Syscall { syscall_decl } |> func_error |> raise
             )) then syscall_decl.return_type
               else Unknow_Function_Error |> func_error |> raise


### PR DESCRIPTION
- Add a new node in ast to declare syscall
- Add an identifier to interop with the C ```void*``` type
