### PR TITLE
Feature/transition before asm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The philosophy of Kosu is to have as control over memory as C (manual memory man
 - [x] Type checking the Ast
 - [x] Annote the Ast with type
 - [x] Create an intermediate representation using the 3 adress code method 
-- [ ] Assembly generation <- Currently here 
+- [ ] Write a register allocator throught graph-coloring method (Will be in an other repository, to be used as a depedency)
+- [ ] Assembly generation
 - [ ] Create a website explaining the syntax and the language in general
 
 ## Example

--- a/lib/frontend/parser.mly
+++ b/lib/frontend/parser.mly
@@ -168,7 +168,7 @@ binary_operator_symbol:
 ;;
 
 operator_decl:
-    | OPERATOR op=located(binary_operator_symbol) fields=delimited(LPARENT, id1=located(IDENT) COLON kt1=located(ktype) COMMA id2=located(IDENT) COLON kt2=located(ktype) { (id1,kt1), (id2, kt2) } , RPARENT) return_type=located(ktype) kbody=kbody {
+    | OPERATOR op=located(binary_operator_symbol) fields=delimited(LPARENT, id1=located(IDENT) COLON kt1=located(ktype) COMMA id2=located(IDENT) COLON kt2=located(ktype) { (id1,kt1), (id2, kt2) } , RPARENT) return_type=located(ktype) kbody=fun_kbody {
         Binary {
             op;
             fields;
@@ -176,7 +176,7 @@ operator_decl:
             kbody
         }
     }
-    | OPERATOR op=delimited(LPARENT, located(unary_operator_symbol), RPARENT) field=delimited(LPARENT, id=located(IDENT) COLON kt=located(ktype) { id, kt} ,RPARENT) return_type=located(ktype) kbody=kbody {
+    | OPERATOR op=delimited(LPARENT, located(unary_operator_symbol), RPARENT) field=delimited(LPARENT, id=located(IDENT) COLON kt=located(ktype) { id, kt} ,RPARENT) return_type=located(ktype) kbody=fun_kbody {
         Unary {
             op;
             field;

--- a/lib/ir/kosutac/asttac.ml
+++ b/lib/ir/kosutac/asttac.ml
@@ -149,7 +149,7 @@ and tac_statement =
       sw_exit_label : string;
     }
 
-and tac_body = { label : string; body : tac_statement list * tac_typed_expression }
+and tac_body = { label : string; body : tac_statement list * tac_typed_expression option }
 
 type tac_function_decl = {
   rfn_name : string;

--- a/lib/ir/kosutac/asttac.ml
+++ b/lib/ir/kosutac/asttac.ml
@@ -44,7 +44,18 @@ type tac_binop_self =
 type tac_binop = TacSelf of tac_binop_self | TacBool of tac_binop_bool
 type tac_unop = TacNot | TacUminus
 
-type tac_expression =
+type tac_local_variable =
+  | Locale of string
+  | Enum_Assoc_id of {
+    name: string;
+    from: tac_typed_expression;
+    assoc_index_bound: int;
+  }
+and tac_typed_locale_variable = {
+  locale_ty: rktype;
+  locale: tac_local_variable
+}
+and tac_expression =
   | TEFalse
   | TETrue
   | TEmpty
@@ -157,6 +168,7 @@ type tac_function_decl = {
   rparameters : (string * rktype) list;
   return_type : rktype;
   tac_body : tac_body;
+  locale_var: tac_typed_locale_variable list;
 }
 
 type tac_operator_decl =
@@ -165,12 +177,14 @@ type tac_operator_decl =
       rfield : string * rktype;
       return_type : rktype;
       tac_body : tac_body;
+      locale_var: tac_typed_locale_variable list;
     }
   | TacBinary of {
       op : parser_binary_op;
       rfields : (string * rktype) * (string * rktype);
       return_type : rktype;
       tac_body : tac_body;
+      locale_var: tac_typed_locale_variable list;
     }
 
 type tac_module_node =

--- a/lib/ir/kosutac/asttacconv.ml
+++ b/lib/ir/kosutac/asttacconv.ml
@@ -45,6 +45,11 @@ module Operator = struct
   let typed_operandes = KosuIrTyped.Asttyped.Binop.operands
 end
 
+let if_count = ref 0
+let cases_count = ref 0
+let switch_count = ref 0
+
+
 let make_tmp = Printf.sprintf "r%u"
 let make_goto_label ~count_if = Printf.sprintf "if.%u.%u" count_if
 let make_end_label ~count_if = Printf.sprintf "if.%u.end" count_if
@@ -681,9 +686,9 @@ let tac_function_decl_of_rfunction (rfunction_decl : rfunction_decl) =
     rparameters = rfunction_decl.rparameters;
     return_type = rfunction_decl.return_type;
     tac_body =
-      convert_from_rkbody ~switch_count:(ref 0) ~cases_count:(ref 0)
+      convert_from_rkbody ~switch_count ~cases_count
         ~label_name:rfunction_decl.rfn_name ~map ~count_var:(ref 0)
-        ~if_count:(ref 0) rfunction_decl.rbody;
+        ~if_count rfunction_decl.rbody;
   }
 
 let tac_operator_decl_of_roperator_decl = function
@@ -701,8 +706,8 @@ let tac_operator_decl_of_roperator_decl = function
           rfield;
           return_type;
           tac_body =
-            convert_from_rkbody ~switch_count:(ref 0) ~cases_count:(ref 0)
-              ~label_name ~map ~count_var:(ref 0) ~if_count:(ref 0)
+            convert_from_rkbody ~switch_count ~cases_count
+              ~label_name ~map ~count_var:(ref 0) ~if_count
               kbody;
         }
   | (RBinary { op; rfields = ((f1, _), (f2, _)) as rfields; return_type; kbody } as self) 
@@ -721,9 +726,9 @@ let tac_operator_decl_of_roperator_decl = function
           rfields;
           return_type;
           tac_body =
-            convert_from_rkbody ~switch_count:(ref 0) ~cases_count:(ref 0)
+            convert_from_rkbody ~switch_count ~cases_count
               ~label_name ~map ~count_var:(ref 0)
-              ~if_count:(ref 0) kbody;
+              ~if_count kbody;
         }
 
 let rec tac_module_node_from_rmodule_node = function

--- a/lib/ir/kosutac/asttacpprint.ml
+++ b/lib/ir/kosutac/asttacpprint.ml
@@ -169,7 +169,7 @@ and string_of_tac_statement = function
 and string_of_tac_body ?(end_jmp = None) (statemements, expression) =
   sprintf "%s\n\t%s%s"
     (statemements |> List.map string_of_tac_statement |> String.concat "\n\t")
-    (string_of_typed_tac_expression expression)
+    (expression |> Option.map (fun e -> sprintf "return %s" (string_of_typed_tac_expression e))  |> Option.value ~default:"" )
     (end_jmp
     |> Option.map (fun s -> sprintf "\n\tjump %s" s)
     |> Option.value ~default:"")

--- a/lib/ir/kosutac/asttacpprint.ml
+++ b/lib/ir/kosutac/asttacpprint.ml
@@ -55,7 +55,7 @@ let rec string_of_typed_locale typed_locale =
     (name)
     (assoc_index_bound)
  in
-  Printf.sprintf "%s :: \"%s\"" sdescri stype 
+  Printf.sprintf "%s: \"%s\"" sdescri stype 
 
 
 and string_of_label_tac_body ?(end_jmp = None) tac_body =

--- a/lib/ir/kosutac/asttacpprint.ml
+++ b/lib/ir/kosutac/asttacpprint.ml
@@ -45,7 +45,20 @@ let symbole_of_binary binary =
   | TacBool TacEqual -> "=="
   | TacBool TacDiff -> "!="
 
-let rec string_of_label_tac_body ?(end_jmp = None) tac_body =
+let rec string_of_typed_locale typed_locale = 
+  let stype = string_of_rktype typed_locale.locale_ty in
+  let sdescri = match typed_locale.locale with
+  | Locale id -> id
+  | Enum_Assoc_id {name; from; assoc_index_bound} -> 
+    Printf.sprintf "%s ==> %s (%d)"
+    (string_of_typed_tac_expression from)
+    (name)
+    (assoc_index_bound)
+ in
+  Printf.sprintf "%s :: \"%s\"" sdescri stype 
+
+
+and string_of_label_tac_body ?(end_jmp = None) tac_body =
   sprintf "%s:\n\t%s \n\n" tac_body.label
     (string_of_tac_body ~end_jmp tac_body.body)
 

--- a/lib/ir/kosutyped/asttyped.ml
+++ b/lib/ir/kosutyped/asttyped.ml
@@ -194,6 +194,12 @@ module RType = struct
   let is_builtin_type = function
     | RTParametric_identifier _ | RTType_Identifier _ -> false
     | _ -> true
+
+  let rec npointer n kt = if n <= 0 then kt else RTPointer (npointer (n-1) kt)
+
+  let rtpointee = function
+  | RTPointer kt -> kt
+  | _ -> failwith "Cannot access pointee type of a none pointer type"
 end
 
 module RSwitch_Case = struct


### PR DESCRIPTION
## Done
- Fix last shift reduce conflict
- Fix label reference count
- Change 3 adress code ast to only have one return 
- store all local variables in the function decl
- Add syntaxic sugar for function decl if it contains only one expression
- Change temporiry and parameters name
- Update the readme