### PR TITLE
Fix/x86 shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## **[Unreleased]**
 
+- X86_64: 
+    - Fix Shift operator
+    - Fix mov integer greater than $2^{31} - 1$
+
 - Integer/Float size inference
 
 - Create Array subscript

--- a/lib/backend/architecture/x86_64/x86_64Conv.ml
+++ b/lib/backend/architecture/x86_64/x86_64Conv.ml
@@ -420,12 +420,12 @@ module Make (Spec : X86_64AsmSpec.X86_64AsmSpecification) = struct
     in
     rinstructions @ linstructions @ copy_instructions
 
-  let translate_tac_binop_self ~litterals ~blhs ~brhs ~where fbinop rval_rktype
-      rprogram fd =
-    let r10 = tmp_r10_ktype blhs.expr_rktype in
-    let rax = tmp_rax_ktype brhs.expr_rktype in
+  let translate_tac_binop_self ~is_shift ~litterals ~blhs ~brhs ~where fbinop
+      rval_rktype rprogram fd =
+    let rax = tmp_rax_ktype blhs.expr_rktype in
+    let rcx = tmp_rcx_ktype brhs.expr_rktype in
     let right_reg, rinstructions =
-      translate_tac_expression ~litterals ~target_dst:(`Register r10) rprogram
+      translate_tac_expression ~litterals ~target_dst:(`Register rcx) rprogram
         fd brhs
     in
     let left_reg, linstructions =
@@ -439,7 +439,14 @@ module Make (Spec : X86_64AsmSpec.X86_64AsmSpecification) = struct
     let reg_size = data_size_of_ktype ~default:Q rprogram rval_rktype in
     let mult_instruction =
       fbinop ~size:reg_size ~destination:(`Register left_reg)
-        ~source:(`Register right_reg)
+        ~source:
+          (`Register
+            ( if is_shift then
+                Register.cl
+              else
+                right_reg
+            )
+            )
     in
     let copy_instruction =
       where
@@ -1435,18 +1442,25 @@ module Make (Spec : X86_64AsmSpec.X86_64AsmSpecification) = struct
         let is_unsigned =
           KosuIrTyped.Asttyhelper.RType.is_raw_unsigned blhs.expr_rktype
         in
+        let is_shift =
+          match self_binop with
+          | TacShiftLeft | TacShiftRight ->
+              true
+          | _ ->
+              false
+        in
         let binop_func =
           binop_instruction_of_tacself ~unsigned:is_unsigned self_binop
         in
-        translate_tac_binop_self ~litterals ~blhs ~brhs ~where binop_func
-          rval_rktype rprogram fd
+        translate_tac_binop_self ~is_shift ~litterals ~blhs ~brhs ~where
+          binop_func rval_rktype rprogram fd
     | RVBuiltinBinop
         { binop = TacSelf ((TacAdd | TacMinus) as self_binop); blhs; brhs } -> (
         match KosuIrTyped.Asttyhelper.RType.is_pointer rval_rktype with
         | false ->
             let binop_func = binop_instruction_of_tacself self_binop in
-            translate_tac_binop_self ~litterals ~blhs ~brhs ~where binop_func
-              rval_rktype rprogram fd
+            translate_tac_binop_self ~is_shift:false ~litterals ~blhs ~brhs
+              ~where binop_func rval_rktype rprogram fd
         | true ->
             let pointee_size =
               rval_rktype |> KosuIrTyped.Asttyhelper.RType.rtpointee

--- a/lib/backend/architecture/x86_64/x86_64Conv.ml
+++ b/lib/backend/architecture/x86_64/x86_64Conv.ml
@@ -159,20 +159,40 @@ module Make (Spec : X86_64AsmSpec.X86_64AsmSpecification) = struct
           ]
         )
     | TEInt (_, isize, int64) ->
+        let is_32bits_encodable = int64 < Int64.of_int32 Int32.max_int in
         let size = data_size_of_isize isize in
         let scaled_data_size = (function Q -> Q | _ -> L) size in
-        ( target_dst,
+        let instrs = match (target_dst, is_32bits_encodable) with
+        | `Register _ as dst, _ | dst , true -> 
           [
             Instruction
               (Mov
                  {
                    size = IntSize scaled_data_size;
                    source = `ILitteral int64;
-                   destination = target_dst;
+                   destination = dst;
                  }
               );
           ]
-        )
+        | `Address _ as dst, _ -> 
+          let r0 = `Register Register.rax in
+          let mov_rax = Instruction (Mov {
+            size = IntSize scaled_data_size;
+            source = `ILitteral int64;
+            destination = r0
+          }) 
+          in
+          let mov_memory = Instruction (
+            Mov {
+              size = IntSize scaled_data_size;
+              source = r0;
+              destination = dst
+            }
+          )
+          in
+          mov_rax::mov_memory::[]
+        in
+        ( target_dst, instrs)
     | TEFloat float ->
         let (FLit float_label) = Hashtbl.find litterals.float_lit_map float in
         let fsize = fst float in

--- a/lib/backend/architecture/x86_64/x86_64Core.ml
+++ b/lib/backend/architecture/x86_64/x86_64Core.ml
@@ -233,6 +233,12 @@ module Register = struct
     else
       rax
 
+  let tmp_rcx_ktype ktype =
+    if KosuIrTyped.Asttyhelper.RType.is_float ktype then
+      xmm1
+    else
+      rcx
+
   let tmp_r9_ktype ktype =
     if KosuIrTyped.Asttyhelper.RType.is_float ktype then
       xmm9


### PR DESCRIPTION
## Done

- Fix shift on x86: since the architecture force the use of rcx 8 bits (cl) to the shift value
- Fix the mov of integer larger than 2^31 