### PR TITLE
Feature/cmdline args opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Add **--framework** option
     - Add **--check_only** option
         - Equivalent of cc ```-fsyntax-only``` option
+    - Fix opaque type mistaken with simple identifier type
 
 - [Opaque type](https://github.com/EruEri/kosu-lang/pull/72)
     - Add pointer to unknown size type (to interop more easily with c library)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+- [Compiler Option]()
+    - Remove **--ccol** option
+        - Now (C, Assembly, Objects) files can be passed as positional arguments
+    - Add **--framework** option
+    - Add **--check_only** option
+        - Equivalent of cc ```-fsyntax-only``` option
+
 - [Opaque type](https://github.com/EruEri/kosu-lang/pull/72)
     - Add pointer to unknown size type (to interop more easily with c library)
     - Fix: exception raised on unknwon type in external declaration

--- a/bin/kosuc.ml
+++ b/bin/kosuc.ml
@@ -15,7 +15,7 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-let () = Printexc.record_backtrace true
-let () = Printexc.print_backtrace stderr
+(* let () = Printexc.record_backtrace true
+   let () = Printexc.print_backtrace stderr *)
 let code = KosucCli.Cli.eval ()
 let () = exit code

--- a/bin/kosuc.ml
+++ b/bin/kosuc.ml
@@ -15,7 +15,7 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-(* let () = Printexc.record_backtrace true
-   let () = Printexc.print_backtrace stderr *)
+let () = Printexc.record_backtrace true
+let () = Printexc.print_backtrace stderr
 let code = KosucCli.Cli.eval ()
 let () = exit code

--- a/lib/backend/architecture/aarch64/aarch64Conv.ml
+++ b/lib/backend/architecture/aarch64/aarch64Conv.ml
@@ -538,7 +538,7 @@ module Make (AsmSpec : Aarch64AsmSpec.Aarch64AsmSpecification) = struct
         | RSyscall_Decl syscall_decl ->
             let instructions, _regs =
               tac_parameters
-              |> Util.ListHelper.combine_safe argument_registers
+              |> Util.Ulist.combine_safe argument_registers
               |> List.fold_left_map
                    (fun acc (reg, tte) ->
                      let reg, instruction =

--- a/lib/backend/architecture/bytecode/compiler/bytecodeConv.ml
+++ b/lib/backend/architecture/bytecode/compiler/bytecodeConv.ml
@@ -401,7 +401,7 @@ let translate_tac_rvalue ~litterals ~where current_module rprogram
             |> List.map @@ cc_args_translate_tac_expression ~litterals fd
           in
           let extra_args =
-            Util.ListHelper.popn
+            Util.Ulist.popn
               (List.length @@ external_func_decl.fn_parameters)
               tac_parameters
           in

--- a/lib/backend/architecture/x86_64/x86_64Conv.ml
+++ b/lib/backend/architecture/x86_64/x86_64Conv.ml
@@ -714,7 +714,7 @@ module Make (Spec : X86_64AsmSpec.X86_64AsmSpecification) = struct
             (* Totally use that syscall args cannot contains float according to the Sys V ABI *)
             let set_on_reg_instructions =
               tac_parameters
-              |> Util.ListHelper.combine_safe syscall_arguments_register
+              |> Util.Ulist.combine_safe syscall_arguments_register
               |> List.fold_left
                    (fun acc (reg, tte) ->
                      let reg = iregister reg in

--- a/lib/backend/compil.ml
+++ b/lib/backend/compil.ml
@@ -15,6 +15,12 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
+type args_file = {
+  c_files : string list;
+  assembly_files : string list;
+  object_files : string list;
+}
+
 module type LinkerOption = sig
   type linker_option
 
@@ -70,80 +76,57 @@ module Make (Codegen : Codegen.S) (LD : LinkerOption) = struct
          )
          pkg_config
 
-  let cc_compilation ?(debug = false) ~ccol ~cclib ~frameworks ~pkg_config_names
-      ~verbose ~outfile ~other tac_prgram =
-    let c_obj_files =
-      ccol
-      |> List.map (fun s ->
-             let tmp_name = Filename.temp_file s ".o" in
-             let cc_cmd = Printf.sprintf "cc -c -o %s %s" tmp_name s in
-             let code = run_command ~verbose cc_cmd in
-             if code = 0 then
-               Ok tmp_name
-             else
-               Error code
-         )
+  let cc_compilation ?(debug = false) ~(args : args_file) ~cclib ~frameworks
+      ~pkg_config_names ~verbose ~outfile tac_prgram =
+    let kosu_asm_files =
+      Codegen.compile_asm_from_tac_tmp ~start:None tac_prgram
     in
-    let error_code =
-      c_obj_files
-      |> List.find_map (function
-           | Error code when code <> 0 ->
-               Some code
-           | _ ->
-               None
-           )
+    let pkg_configs =
+      pkg_config ~verbose ~cflags:true ~clibs:true ~pkg_config_names ()
     in
-    match error_code with
-    | Some s ->
-        s
-    | None ->
-        let asm_files =
-          Codegen.compile_asm_from_tac_tmp ~start:None tac_prgram
-        in
-        let obj_file = c_obj_files |> List.map Result.get_ok in
-        let pkg_configs =
-          pkg_config ~verbose ~cflags:true ~clibs:true ~pkg_config_names ()
-        in
 
-        let frameworks =
-          frameworks
-          |> List.map @@ Printf.sprintf "-framework %s"
-          |> String.concat " "
-        in
+    let frameworks =
+      frameworks
+      |> List.map @@ Printf.sprintf "-framework %s"
+      |> String.concat " "
+    in
 
-        let pkg_configs = pkg_append_lib cclib pkg_configs in
-        let cmd =
-          Printf.sprintf "cc %s -o %s %s %s %s %s"
-            ( if debug then
-                "-g"
-              else
-                ""
-            )
-            outfile
-            (asm_files |> String.concat " ")
-            (obj_file @ other |> String.concat " ")
-            frameworks
-            (Util.PkgConfig.to_string pkg_configs)
-        in
-        run_command ~verbose cmd
+    let pkg_configs = pkg_append_lib cclib pkg_configs in
+    let sdebug =
+      if debug then
+        "-g"
+      else
+        ""
+    in
+    let args =
+      args.c_files @ args.assembly_files @ args.object_files @ kosu_asm_files
+    in
+    let files = String.concat " " args in
+    let cmd =
+      Printf.sprintf "cc %s -o %s %s %s %s" sdebug outfile files frameworks
+        (Util.PkgConfig.to_string pkg_configs)
+    in
+    run_command ~verbose cmd
 
-  let native_compilation ?(debug = false) ~ccol ~cclib ~frameworks
-      ~pkg_config_names ~verbose ~outfile ~other tac_prgram =
+  let native_compilation ?(debug = false) ~(args : args_file) ~cclib ~frameworks
+      ~pkg_config_names ~verbose ~outfile tac_prgram =
+    let _ = ignore debug in
     let () =
       match LD.disable with
       | Some message ->
-          Printf.eprintf "%s\n" message;
+          let () = Printf.eprintf "%s\n" message in
           exit 1
       | None ->
           ()
     in
-    let _ = ignore debug in
+
     let out_file = outfile in
     let pkg =
-      pkg_config ~verbose ~cflags:(ccol <> []) ~clibs:true ~pkg_config_names ()
+      pkg_config ~verbose ~cflags:(args.c_files <> []) ~clibs:true
+        ~pkg_config_names ()
     in
     let c_obj_files =
-      ccol
+      args.c_files
       |> List.map (fun s ->
              let tmp_name = Filename.temp_file s ".o" in
              let cmd =
@@ -162,22 +145,8 @@ module Make (Codegen : Codegen.S) (LD : LinkerOption) = struct
       Codegen.compile_asm_from_tac_tmp ~start:LD.should_create_entry_point
         tac_prgram
     in
-    let ccol_obj_files = c_obj_files in
 
-    let other_object_files, other_asm_files =
-      other
-      |> List.filter (fun file ->
-             Util.is_asm_file file || Util.is_object_file file
-         )
-      |> List.partition_map (fun file ->
-             if Util.is_object_file file then
-               Either.left file
-             else
-               Either.right file
-         )
-    in
-
-    let asm_files = kosu_asm_files @ other_asm_files in
+    let asm_files = kosu_asm_files @ args.assembly_files in
     let asm_to_object_files =
       asm_files
       |> List.map (fun file ->
@@ -192,9 +161,7 @@ module Make (Codegen : Codegen.S) (LD : LinkerOption) = struct
          )
     in
 
-    let objects_files =
-      ccol_obj_files @ other_object_files @ asm_to_object_files
-    in
+    let objects_files = c_obj_files @ args.object_files @ asm_to_object_files in
     let string_of_objects_files = objects_files |> String.concat " " in
     let options =
       LD.options

--- a/lib/commandline/cliCommon/cliCommon.ml
+++ b/lib/commandline/cliCommon/cliCommon.ml
@@ -18,6 +18,43 @@
 type architecture = Arm64 | X86_64
 type os = Macos | Linux | FreeBSD
 type large_architecture = LArm64 | LX86_64 | LKVM
+type suppoted_file = SF_Kosu | SF_C | SF_Object | SF_Assembly
+
+let extension_list =
+  [ (SF_C, ".c"); (SF_Object, ".o"); (SF_Kosu, ".kosu"); (SF_Assembly, ".s") ]
+
+let rev_extension_list =
+  let swap (a, b) = (b, a) in
+  List.map swap extension_list
+
+let rec input_file ~kosu ~c ~co ~assembly = function
+  | [] ->
+      Ok (List.rev kosu, List.rev c, List.rev co, List.rev assembly)
+  | t :: q ->
+      let ( let* ) = Result.bind in
+      let filekind = List.assoc_opt (Filename.extension t) rev_extension_list in
+      let* kind =
+        match filekind with None -> Error t | Some kind -> Ok kind
+      in
+      let kosu, c, co, assembly =
+        match kind with
+        | SF_C ->
+            (kosu, t :: c, co, assembly)
+        | SF_Object ->
+            (kosu, c, t :: co, assembly)
+        | SF_Kosu ->
+            (t :: kosu, c, co, assembly)
+        | SF_Assembly ->
+            (kosu, c, co, t :: assembly)
+      in
+      input_file ~kosu ~c ~co ~assembly q
+
+let input_file files =
+  match input_file ~kosu:[] ~c:[] ~co:[] ~assembly:[] files with
+  | Ok (kosu, c, co, assembly) ->
+      Ok (`KosuFile kosu, `CFile c, `ObjFile co, `AssemblyFile assembly)
+  | Error _ as e ->
+      e
 
 let large_architecture_enum =
   [ ("arm64", LArm64); ("x86_64", LX86_64); ("kvm", LKVM) ]

--- a/lib/commandline/kosuCli/kosuCfgSubc.ml
+++ b/lib/commandline/kosuCli/kosuCfgSubc.ml
@@ -39,7 +39,7 @@ let register_module = function
   | LKVM ->
       (module BytecodeCompiler.Register : KosuIrCfg.Asttaccfg.ABI_Large
         with type variable = KosuIrCfg.Asttaccfg.Cfg_Sig_Impl.variable
-      )
+    )
   | LArm64 ->
       failwith "Not implemented yet"
   | LX86_64 ->

--- a/lib/commandline/kosucCli/kosucCli.ml
+++ b/lib/commandline/kosucCli/kosucCli.ml
@@ -46,6 +46,7 @@ module Cli = struct
   type cmd = {
     architecture : architecture;
     os : os;
+    check_only : bool;
     f_allow_generic_in_variadic : bool;
     no_std : bool;
     is_target_asm : bool;
@@ -83,6 +84,13 @@ module Cli = struct
                architecture_global_variable
             )
           ~doc:"architecture compilation target" [ "arch" ]
+    )
+
+  let check_only_term =
+    Arg.(
+      value & flag
+      & info [ "check-only" ]
+          ~doc:"Run only the parsing and type checking stages"
     )
 
   let os_target_term =
@@ -192,12 +200,13 @@ module Cli = struct
     )
 
   let cmd_term run =
-    let combine architecture os f_allow_generic_in_variadic no_std verbose cc
-        is_target_asm output pkg_configs cclib frameworks files =
+    let combine architecture os check_only f_allow_generic_in_variadic no_std
+        verbose cc is_target_asm output pkg_configs cclib frameworks files =
       run
       @@ {
            architecture;
            f_allow_generic_in_variadic;
+           check_only;
            os;
            no_std;
            verbose;
@@ -211,7 +220,7 @@ module Cli = struct
          }
     in
     Term.(
-      const combine $ target_archi_term $ os_target_term
+      const combine $ target_archi_term $ os_target_term $ check_only_term
       $ f_allow_generic_in_variadic_term $ no_std_term $ verbose_term $ cc_term
       $ target_asm_term $ output_term $ pkg_config_term $ cclib_term
       $ framework_term $ files_term
@@ -273,6 +282,7 @@ module Cli = struct
     let {
       architecture;
       os;
+      check_only;
       f_allow_generic_in_variadic;
       no_std;
       verbose;
@@ -351,6 +361,8 @@ module Cli = struct
           in
           failwith "Error while typing ast: Shouldn't append"
     in
+
+    let () = match check_only with true -> exit 0 | false -> () in
 
     let tac_program =
       KosuIrTAC.Asttacconv.tac_program_of_rprogram typed_program

--- a/lib/frontend/ast.ml
+++ b/lib/frontend/ast.ml
@@ -296,14 +296,10 @@ module Fsize = struct
 end
 
 module Type_Decl = struct
-  type type_decl =
-    | Decl_Enum of enum_decl
-    | Decl_Struct of struct_decl
-    | Decl_Opaque of opaque_decl
+  type type_decl = Decl_Enum of enum_decl | Decl_Struct of struct_decl
 
   let decl_enum e = Decl_Enum e
   let decl_struct s = Decl_Struct s
-  let decl_opaque o = Decl_Opaque o
 end
 
 module Function_Decl = struct
@@ -564,6 +560,11 @@ module Error = struct
         position : position;
         ktype : ktype;
       }
+    | Opque_type_tag of {
+        fn_name : string;
+        position : position;
+        opaque_decl : opaque_decl;
+      }
     | Wrong_parameters of {
         fn_name : string;
         expected : ktype;
@@ -629,6 +630,7 @@ module Error = struct
     | Undefined_Struct of string location
     | Unbound_Module of string location
     | Undefine_Type of string location
+    | Undefine_OpaqueType of string location
     | Undefine_function of string location
     | Struct_Error of struct_error
     | Enum_Error of enum_error

--- a/lib/frontend/ast.ml
+++ b/lib/frontend/ast.ml
@@ -843,7 +843,7 @@ module Type = struct
         TParametric_identifier
           { module_path = mp2; parametrics_type = pt2; name = n2 } ) ->
         n1.v = n2.v && mp1.v = mp2.v
-        && pt1 |> Util.are_same_lenght pt2
+        && pt1 |> Util.Ulist.are_same_length pt2
         && List.for_all2 (fun kt1 kt2 -> kt1.v === kt2.v) pt1 pt2
     | TPointer pt1, TPointer pt2 ->
         pt1.v === pt2.v
@@ -851,7 +851,7 @@ module Type = struct
         TType_Identifier { module_path = mp2; name = n2 } ) ->
         mp1.v = mp2.v && n1.v = n2.v
     | TTuple t1, TTuple t2 ->
-        Util.are_same_lenght t1 t2
+        Util.Ulist.are_same_length t1 t2
         && List.combine t1 t2
            |> List.map Position.assocs_value
            |> List.for_all (fun (k1, k2) -> k1 === k2)
@@ -895,7 +895,7 @@ module Type = struct
         TParametric_identifier
           { module_path = mp2; parametrics_type = pt2; name = n2 } ) ->
         n1.v = n2.v && mp1.v = mp2.v
-        && pt1 |> Util.are_same_lenght pt2
+        && pt1 |> Util.Ulist.are_same_length pt2
         && List.for_all2
              (fun kt1 kt2 -> are_compatible_type kt1.v kt2.v)
              pt1 pt2
@@ -911,7 +911,7 @@ module Type = struct
         TType_Identifier { module_path = mp2; name = n2 } ) ->
         mp1.v = mp2.v && n1.v = n2.v
     | TTuple t1, TTuple t2 ->
-        Util.are_same_lenght t1 t2
+        Util.Ulist.are_same_length t1 t2
         && List.combine t1 t2
            |> List.map Position.assocs_value
            |> List.for_all (fun (k1, k2) -> are_compatible_type k1 k2)
@@ -947,7 +947,9 @@ module Type = struct
           { module_path = lmp; parametrics_type = lpt; name = lname },
         TParametric_identifier
           { module_path = rmp; parametrics_type = rpt; name = rname } ) ->
-        if lmp.v <> rmp.v || lname.v <> rname.v || Util.are_diff_lenght lpt rpt
+        if
+          lmp.v <> rmp.v || lname.v <> rname.v
+          || Util.Ulist.are_diff_length lpt rpt
         then
           ()
         else
@@ -1219,7 +1221,9 @@ module Type = struct
             { module_path = mp1; parametrics_type = pt1; name = n1 },
           TParametric_identifier
             { module_path = mp2; parametrics_type = pt2; name = n2 } ) ->
-          if n1.v <> n2.v || mp1.v <> mp2.v || Util.are_diff_lenght pt1 pt2 then
+          if
+            n1.v <> n2.v || mp1.v <> mp2.v || Util.Ulist.are_diff_length pt1 pt2
+          then
             to_restrict_type
           else
             TParametric_identifier

--- a/lib/frontend/asthelper.ml
+++ b/lib/frontend/asthelper.ml
@@ -70,6 +70,13 @@ module Module = struct
                match node with Ast.NConst s -> Some s | _ -> None
            )
 
+  let retrieve_opaque_decl = function
+    | Ast.Mod nodes ->
+        nodes
+        |> List.filter_map (fun node ->
+               match node with Ast.NOpaque s -> Some s | _ -> None
+           )
+
   let retrieve_type_decl = function
     | Ast.Mod nodes ->
         nodes
@@ -79,8 +86,6 @@ module Module = struct
                    Some (Ast.Type_Decl.decl_enum e)
                | Ast.NStruct s ->
                    Some (Ast.Type_Decl.decl_struct s)
-               | Ast.NOpaque s ->
-                   Some (Ast.Type_Decl.decl_opaque s)
                | _ ->
                    None
            )
@@ -121,9 +126,12 @@ module Module = struct
              e.enum_name.v = type_name
          | Ast.Type_Decl.Decl_Struct s ->
              s.struct_name.v = type_name
-         | Ast.Type_Decl.Decl_Opaque s ->
-             s.v = type_name
          )
+
+  let opaque_type_occurence (opaque_name : string)
+      (module_definition : Ast._module) =
+    module_definition |> retrieve_opaque_decl
+    |> Util.Occurence.find_occurence (function decl -> opaque_name = decl.v)
 
   let function_decl_occurence (fn_name : string)
       (module_definition : Ast._module) =
@@ -258,6 +266,39 @@ module Program = struct
                module_path.path = s
            )
 
+  let find_module ~current_module fn_def_path program =
+    match fn_def_path with
+    | "" ->
+        program
+        |> Util.Occurence.find_occurence (fun module_path ->
+               module_path.path = current_module
+           )
+    | s ->
+        program
+        |> Util.Occurence.find_occurence (fun module_path ->
+               module_path.path = s
+           )
+
+  let find_opaque_type_declaration ~current_module ~module_path ~name program =
+    let ( let* ) = Result.bind in
+    let* module_decl =
+      match find_module ~current_module module_path.v program with
+      | Util.Occurence.Empty ->
+          Result.error @@ Ast.Error.Unbound_Module module_path
+      | Util.Occurence.One module_path ->
+          Ok module_path
+      | Util.Occurence.Multiple module_paths ->
+          Result.error
+          @@ Ast.Error.Conflicting_module_path_declaration
+               { module_path; choices = module_paths }
+    in
+    match Module.opaque_type_occurence name.v module_decl._module with
+    | Util.Occurence.Empty | Util.Occurence.Multiple [] ->
+        Result.error @@ Ast.Error.Undefine_OpaqueType name
+    (* Pass because multiple opaque type with the same name are trated as the same*)
+    | Util.Occurence.One m | Util.Occurence.Multiple (m :: _) ->
+        Result.ok m
+
   (**
     Find type declaration from ktype
   *)
@@ -289,7 +330,7 @@ module Program = struct
         |> Result.error
 
   (**
-      Find type declaration from ktype
+      Find type declaration from ktype or opaque type declaration
       @return type_decl if ktype came from a type declaration, [None] if ktype is a builtin type
       @raise Ast_error: if length of assoc_type is not the same as the length of the generic of the type declaration found
     *)
@@ -300,16 +341,12 @@ module Program = struct
           e.generics
       | Ast.Type_Decl.Decl_Struct s ->
           s.generics
-      | Ast.Type_Decl.Decl_Opaque _ ->
-          []
     in
     let type_name = function
       | Ast.Type_Decl.Decl_Enum e ->
           e.enum_name
       | Ast.Type_Decl.Decl_Struct s ->
           s.struct_name
-      | Ast.Type_Decl.Decl_Opaque s ->
-          s
     in
     match ktype with
     | TType_Identifier { module_path = ktype_def_path; name = ktype_name } ->
@@ -339,7 +376,7 @@ module Program = struct
               }
             |> Ast.Error.ast_error |> raise
           else
-            type_decl |> Option.some
+            Option.some @@ Either.left @@ type_decl
     | TParametric_identifier
         { module_path = ktype_def_path; parametrics_type; name = ktype_name } ->
         let _ =
@@ -373,7 +410,7 @@ module Program = struct
             }
           |> Ast.Error.ast_error |> raise
         else
-          type_decl |> Option.some
+          Option.some @@ Either.left @@ type_decl
     | TPointer kt ->
         find_type_decl_from_true_ktype ~generics kt.v current_module program
     | TTuple kts ->
@@ -386,18 +423,18 @@ module Program = struct
                ()
            );
         None
-    | TOpaque { module_path = ktype_def_path; name = ktype_name } ->
+    | TOpaque { module_path; name } ->
         let type_decl =
           match
-            find_type_decl_from_ktype ~ktype_def_path ~ktype_name
-              ~current_module program
+            find_opaque_type_declaration ~module_path ~name ~current_module
+              program
           with
           | Error e ->
               e |> Ast.Error.ast_error |> raise
           | Ok type_decl ->
               type_decl
         in
-        Some type_decl
+        Option.some @@ Either.right @@ type_decl
     | TOredered
     | TString_lit
     | TUnknow
@@ -444,8 +481,6 @@ module Program = struct
   let rec is_c_type current_mod_name (type_decl : Ast.Type_Decl.type_decl)
       program =
     match type_decl with
-    | Ast.Type_Decl.Decl_Opaque _ ->
-        true
     | Decl_Enum e ->
         e.generics = []
         && e.variants |> List.for_all (fun (_, assoc) -> assoc = [])
@@ -1602,8 +1637,6 @@ module Struct = struct
     let open Ast.Type_Decl in
     let open Ast.Error in
     match type_decl with
-    | Ast.Type_Decl.Decl_Opaque s ->
-        raise @@ ast_error @@ Opaque_field_access { field; opaque = s }
     | Decl_Enum enum_decl ->
         Enum_Access_field { field; enum_decl } |> ast_error |> raise
     | Decl_Struct struct_decl -> (
@@ -1741,40 +1774,30 @@ module Type_Decl = struct
         e.enum_name
     | Ast.Type_Decl.Decl_Struct s ->
         s.struct_name
-    | Ast.Type_Decl.Decl_Opaque s ->
-        s
 
   let generics = function
     | Ast.Type_Decl.Decl_Enum e ->
         e.generics
     | Ast.Type_Decl.Decl_Struct s ->
         s.generics
-    | Ast.Type_Decl.Decl_Opaque _ ->
-        []
 
   let is_ktype_generic kt = function
     | Ast.Type_Decl.Decl_Enum e ->
         e |> Enum.is_type_generic kt
     | Ast.Type_Decl.Decl_Struct s ->
         s |> Struct.is_type_generic kt
-    | Ast.Type_Decl.Decl_Opaque _ ->
-        false
 
   let is_ktype_generic_level_zero kt = function
     | Ast.Type_Decl.Decl_Enum e ->
         e |> Enum.is_ktype_generic_level_zero kt
     | Ast.Type_Decl.Decl_Struct s ->
         s |> Struct.is_ktype_generic_level_zero kt
-    | Ast.Type_Decl.Decl_Opaque _ ->
-        false
 
   let remove_level_zero_genenics kts = function
     | Ast.Type_Decl.Decl_Enum e ->
         e |> Enum.remove_level_zero_genenics kts
     | Ast.Type_Decl.Decl_Struct s ->
         s |> Struct.remove_level_zero_genenics kts
-    | Ast.Type_Decl.Decl_Opaque _ ->
-        []
 
   let are_same_type_decl lhs rhs =
     lhs |> type_name |> Position.value = (rhs |> type_name |> Position.value)
@@ -1978,9 +2001,9 @@ module Builtin_Function = struct
             in
             let res =
               match type_decl with
-              | Some (Decl_Enum _) ->
+              | Some (Either.Left (Decl_Enum _)) ->
                   Result.ok fn
-              | Some (Decl_Struct _) ->
+              | Some (Either.Left (Decl_Struct _)) ->
                   Result.error
                   @@ Struct_type_tag
                        {
@@ -1988,8 +2011,14 @@ module Builtin_Function = struct
                          position = t.position;
                          ktype = t.v;
                        }
-              | Some (Decl_Opaque _) ->
-                  failwith "Tag opaque"
+              | Some (Either.Right opaque_decl) ->
+                  Result.error
+                  @@ Opque_type_tag
+                       {
+                         fn_name = fn_location.v;
+                         position = t.position;
+                         opaque_decl;
+                       }
               | None ->
                   Result.error
                   @@ Builin_type_tag
@@ -2435,8 +2464,6 @@ module Affected_Value = struct
         match type_decl with
         | Decl_Enum enum_decl ->
             Enum_Access_field { field = t; enum_decl } |> ast_error |> raise
-        | Ast.Type_Decl.Decl_Opaque s ->
-            raise @@ ast_error @@ Opaque_field_access { field = t; opaque = s }
         | Decl_Struct struct_decl -> (
             match
               Struct.ktype_of_field_gen ~current_module:current_mod_name
@@ -2453,8 +2480,6 @@ module Affected_Value = struct
         match type_decl with
         | Decl_Enum enum_decl ->
             Enum_Access_field { field = t; enum_decl } |> ast_error |> raise
-        | Ast.Type_Decl.Decl_Opaque s ->
-            raise @@ ast_error @@ Opaque_field_access { field = t; opaque = s }
         | Decl_Struct struct_decl -> (
             match
               Struct.ktype_of_field_gen ~current_module:current_mod_name

--- a/lib/frontend/asthelper.ml
+++ b/lib/frontend/asthelper.ml
@@ -106,7 +106,7 @@ module Module = struct
     |> Util.Occurence.find_occurence (fun fn_decl ->
            fn_decl.fn_name = fn_name
            && Ast.Type.are_compatible_type r_types.v fn_decl.return_type.v
-           && Util.are_same_lenght fn_decl.parameters parameters_types
+           && Util.Ulist.are_same_length fn_decl.parameters parameters_types
            && List.for_all2
                 (fun para init -> Ast.Type.are_compatible_type para.v init.v)
                 (fn_decl.parameters |> List.map (fun (_, kt) -> kt))
@@ -206,14 +206,15 @@ module Program = struct
                    enum_decl.variants
                    |> List.exists (fun (variant_decl, assoc_type) ->
                           variant_decl.v = variant.v
-                          && Util.are_same_lenght assoc_exprs assoc_type
+                          && Util.Ulist.are_same_length assoc_exprs assoc_type
                       )
                | Some enum_name ->
                    enum_name = enum_decl.enum_name.v
                    && enum_decl.variants
                       |> List.exists (fun (variant_decl, assoc_type) ->
                              variant_decl.v = variant.v
-                             && Util.are_same_lenght assoc_exprs assoc_type
+                             && Util.Ulist.are_same_length assoc_exprs
+                                  assoc_type
                          )
            )
         |> function
@@ -553,7 +554,7 @@ module Program = struct
               let declaration =
                 program |> find_binary_operator op (kt, kt) rtype
               in
-              match declaration |> Util.ListHelper.inner_count with
+              match declaration |> Util.Ulist.inner_count with
               | 0 ->
                   Result.error No_declaration_found
               | 1 ->
@@ -580,7 +581,7 @@ module Program = struct
       match lhs with
       | TType_Identifier _ as kt -> (
           let declaration = program |> find_binary_operator op (kt, kt) rtype in
-          match declaration |> Util.ListHelper.inner_count with
+          match declaration |> Util.Ulist.inner_count with
           | 0 -> (
               match no_decl with
               | Some f ->
@@ -705,7 +706,7 @@ module Program = struct
     match ktype with
     | TType_Identifier _ as kt -> (
         let declaration = program |> find_unary_operator Ast.PNot kt kt in
-        match declaration |> Util.ListHelper.inner_count with
+        match declaration |> Util.Ulist.inner_count with
         | 0 ->
             `no_function_found
         | 1 ->
@@ -725,7 +726,7 @@ module Program = struct
     match ktype with
     | TType_Identifier _ as kt -> (
         let declaration = program |> find_unary_operator Ast.PUMinus kt kt in
-        match declaration |> Util.ListHelper.inner_count with
+        match declaration |> Util.Ulist.inner_count with
         | 0 ->
             `no_function_found
         | 1 ->
@@ -1156,7 +1157,7 @@ module Switch_case = struct
         matched_variant.v = variant.v && assoc_types |> List.length = 0
     | SC_Enum_Identifier_Assoc { variant = matched_variant; assoc_ids } ->
         matched_variant.v = variant.v
-        && Util.are_same_lenght assoc_ids assoc_types
+        && Util.Ulist.are_same_length assoc_ids assoc_types
 
   let is_cases_matched variant (switch_cases : t list) =
     switch_cases |> List.exists (is_case_matched variant)
@@ -1213,7 +1214,7 @@ module Enum = struct
     | TPointer l_type, TPointer r_type ->
         are_type_compatible l_type.v r_type.v enum_decl
     | TTuple lhs, TTuple rhs ->
-        Util.are_same_lenght lhs rhs
+        Util.Ulist.are_same_length lhs rhs
         && List.combine lhs rhs
            |> List.for_all (fun (lhs_type, rhs_type) ->
                   are_type_compatible lhs_type.v rhs_type.v enum_decl
@@ -1241,7 +1242,7 @@ module Enum = struct
                  let () =
                    Hashtbl.replace generic_table name.v
                      ( enum_decl.generics
-                       |> Util.ListHelper.index_of (fun ge -> ge.v = name.v),
+                       |> Util.Ulist.index_of (fun ge -> ge.v = name.v),
                        kt
                      )
                  in
@@ -1277,7 +1278,7 @@ module Enum = struct
     | TPointer l_type, TPointer r_type ->
         is_type_compatible_hashgen generic_table l_type.v r_type.v enum_decl
     | TTuple lhs, TTuple rhs ->
-        Util.are_same_lenght lhs rhs
+        Util.Ulist.are_same_length lhs rhs
         && List.combine lhs rhs
            |> List.for_all (fun (lhs_type, rhs_type) ->
                   is_type_compatible_hashgen generic_table lhs_type.v rhs_type.v
@@ -1308,7 +1309,7 @@ module Enum = struct
         }
 
   let is_valide_assoc_type_init ~init_types ~expected_types enum_decl =
-    Util.are_same_lenght init_types expected_types
+    Util.Ulist.are_same_length init_types expected_types
     && List.combine init_types expected_types
        |> List.for_all (fun (init_type, expected_type) ->
               are_type_compatible init_type expected_type enum_decl
@@ -1641,7 +1642,7 @@ module Struct = struct
                  let () =
                    Hashtbl.replace generic_table name.v
                      ( struct_decl.generics |> List.map Position.value
-                       |> Util.ListHelper.index_of (( = ) name.v),
+                       |> Util.Ulist.index_of (( = ) name.v),
                        kt
                      )
                  in
@@ -1682,7 +1683,7 @@ module Struct = struct
         && is_type_compatible_hashgen generic_table lhs.ktype.v rhs.ktype.v
              struct_decl
     | TTuple lhs, TTuple rhs ->
-        Util.are_same_lenght lhs rhs
+        Util.Ulist.are_same_length lhs rhs
         && List.for_all2
              (fun init exptected ->
                is_type_compatible_hashgen generic_table init exptected
@@ -2140,7 +2141,7 @@ module Function = struct
                  let () =
                    Hashtbl.replace generic_table name.v
                      ( function_decl.generics
-                       |> Util.ListHelper.index_of (fun g -> g.v = name.v),
+                       |> Util.Ulist.index_of (fun g -> g.v = name.v),
                        kt
                      )
                  in
@@ -2184,7 +2185,7 @@ module Function = struct
     | TPointer lhs, TPointer rhs ->
         is_type_compatible_hashgen generic_table lhs.v rhs.v function_decl
     | TTuple lhs, TTuple rhs ->
-        Util.are_same_lenght lhs rhs
+        Util.Ulist.are_same_length lhs rhs
         && List.for_all2
              (fun lkt rkt ->
                is_type_compatible_hashgen generic_table lkt.v rkt.v

--- a/lib/frontend/astvalidation.ml
+++ b/lib/frontend/astvalidation.ml
@@ -1108,7 +1108,7 @@ struct
               acc
             else
               validate_module
-                (remove_program |> Asthelper.Program.to_module_path_list)
+                (Asthelper.Program.to_module_path_list remove_program)
                 named_module_path
           )
           ("", Ok ()) remove_program

--- a/lib/frontend/pprint.ml
+++ b/lib/frontend/pprint.ml
@@ -485,8 +485,6 @@ let string_of_type_decl = function
       string_of_enum_decl e
   | Ast.Type_Decl.Decl_Struct s ->
       string_of_struct_decl s
-  | Ast.Type_Decl.Decl_Opaque s ->
-      Printf.sprintf "opaque(%s)" s.v
 
 let string_of_signature fn_name parameters return_type =
   sprintf "%s(%s)%s" fn_name.v

--- a/lib/frontend/pprinterr.ml
+++ b/lib/frontend/pprinterr.ml
@@ -444,6 +444,12 @@ struct
              "Builtin function \"%s\", this expression has the type \"%s\" \
               which is a struct type and not an enum"
              fn_name (string_of_ktype ktype)
+    | Opque_type_tag { fn_name; position; opaque_decl } ->
+        string_of_positioned_error position
+        @@ sprintf
+             "Builtin function \"%s\", this expression has the type \"%s\" \
+              which is an opaque type and not an enum"
+             fn_name opaque_decl.v
 
   let quoted = sprintf "\"%s\""
 
@@ -484,6 +490,8 @@ struct
         string_of_located_error s (sprintf "Unbound Module \"%s\"" s.v)
     | Undefine_Type s ->
         string_of_located_error s (sprintf "Undefined Type \"%s\"" s.v)
+    | Undefine_OpaqueType s ->
+        string_of_located_error s (sprintf "Undefined Opaque Type \"#%s\"" s.v)
     | Struct_Error s ->
         string_of_struct_error s
     | Enum_Error e ->

--- a/lib/frontend/typecheck.ml
+++ b/lib/frontend/typecheck.ml
@@ -1656,7 +1656,7 @@ Return the type of an expression
           with
           | Ok (Type_Decl.Decl_Enum e) ->
               e
-          | Ok (Type_Decl.Decl_Struct _ | Type_Decl.Decl_Opaque _) ->
+          | Ok (Type_Decl.Decl_Struct _) ->
               raise @@ switch_error
               @@ Not_enum_type_in_switch_Expression
                    (expr |> Position.map (fun _ -> expr_type))
@@ -1975,12 +1975,12 @@ Return the type of an expression
           with
           | None ->
               failwith "enum case as builint type"
-          | Some (Decl_Struct _) ->
+          | Some (Left (Decl_Struct _)) ->
               failwith "match struct instead of enum"
-          | Some (Decl_Opaque _) ->
-              failwith "opaque match enum"
-          | Some (Decl_Enum e) ->
+          | Some (Left (Decl_Enum e)) ->
               e
+          | Some (Right _) ->
+              failwith "match opaque type"
         in
         let generic_map =
           scrutinee_type |> Type.extract_parametrics_ktype

--- a/lib/frontend/typecheck.ml
+++ b/lib/frontend/typecheck.ml
@@ -888,7 +888,7 @@ Return the type of an expression
               failwith "Wierd to fall here"
         in
         let () =
-          if Util.are_diff_lenght assoc_exprs raw_associated_types then
+          if Util.Ulist.are_diff_length assoc_exprs raw_associated_types then
             raise @@ enum_error
             @@ Ast.Error.Wrong_length_assoc_type
                  {
@@ -925,7 +925,7 @@ Return the type of an expression
           |> Option.get
           |> fun assoc_types ->
           let () =
-            if Util.are_diff_lenght init_types assoc_types then
+            if Util.Ulist.are_diff_length init_types assoc_types then
               raise @@ Ast.Error.enum_error
               @@ Ast.Error.Wrong_length_assoc_type
                    {
@@ -1160,7 +1160,9 @@ Return the type of an expression
         match fn_decl with
         | Ast.Function_Decl.Decl_Kosu_Function kosu_function_decl ->
             let () =
-              if Util.are_diff_lenght parameters kosu_function_decl.parameters
+              if
+                Util.Ulist.are_diff_length parameters
+                  kosu_function_decl.parameters
               then
                 raise @@ func_error
                 @@ Unmatched_Parameters_length
@@ -1218,7 +1220,7 @@ Return the type of an expression
               | true ->
                   let () =
                     if
-                      Util.are_diff_lenght
+                      Util.Ulist.are_diff_length
                         (grc |> Option.value ~default:[])
                         kosu_function_decl.generics
                     then
@@ -1316,8 +1318,8 @@ Return the type of an expression
               | false ->
                   let () =
                     if
-                      Util.are_diff_lenght external_func_decl.fn_parameters
-                        parameters
+                      Util.Ulist.are_diff_length
+                        external_func_decl.fn_parameters parameters
                     then
                       raise @@ func_error
                       @@ Unmatched_Parameters_length
@@ -1367,7 +1369,8 @@ Return the type of an expression
               external_func_decl.r_type.v
         | Ast.Function_Decl.Decl_Syscall syscall_decl ->
             let () =
-              if Util.are_diff_lenght syscall_decl.parameters parameters then
+              if Util.Ulist.are_diff_length syscall_decl.parameters parameters
+              then
                 raise @@ func_error
                 @@ Unmatched_Parameters_length
                      {
@@ -1932,7 +1935,7 @@ Return the type of an expression
               failwith "unmatched between scrutinee type and pattern type"
         in
         let () =
-          match Util.are_same_lenght patterns tuple_scrutinee with
+          match Util.Ulist.are_same_length patterns tuple_scrutinee with
           | true ->
               ()
           | false ->
@@ -1954,9 +1957,7 @@ Return the type of an expression
         in
         let bounds = List.flatten bounds in
         let duplicated =
-          Util.ListHelper.duplicated
-            (fun (lhs, _) (rhs, _) -> lhs.v = rhs.v)
-            bounds
+          Util.Ulist.duplicated (fun (lhs, _) (rhs, _) -> lhs.v = rhs.v) bounds
         in
         let () =
           match duplicated with
@@ -1997,7 +1998,7 @@ Return the type of an expression
               assoc
         in
         let () =
-          match Util.are_same_lenght assoc_patterns assoc_type with
+          match Util.Ulist.are_same_length assoc_patterns assoc_type with
           | true ->
               ()
           | false ->
@@ -2018,9 +2019,7 @@ Return the type of an expression
         in
         let bounds = List.flatten bounds in
         let duplicated =
-          Util.ListHelper.duplicated
-            (fun (lhs, _) (rhs, _) -> lhs.v = rhs.v)
-            bounds
+          Util.Ulist.duplicated (fun (lhs, _) (rhs, _) -> lhs.v = rhs.v) bounds
         in
         let () =
           match duplicated with
@@ -2072,7 +2071,7 @@ Return the type of an expression
           others_identifier
           |> List.fold_left
                (fun acc bounds ->
-                 match Util.ListHelper.ldiff string_compare acc bounds with
+                 match Util.Ulist.ldiff string_compare acc bounds with
                  | [] ->
                      acc
                  | t :: _ ->

--- a/lib/ir/kosutyped/asttyhelper.ml
+++ b/lib/ir/kosutyped/asttyhelper.ml
@@ -1275,8 +1275,8 @@ module RProgram = struct
                 parameters
                 |> List.combine function_decl.rparameters
                 |> List.map
-                     (fun ((_, type_decl), ({ rktype; rexpression = _ } as te))
-                     ->
+                     (fun
+                       ((_, type_decl), ({ rktype; rexpression = _ } as te)) ->
                        (* let () = Printf.printf "te: %s\n\n" (Asttypprint.string_of_typed_expression te) in *)
                        let _ =
                          Function.is_type_compatible_hashgen maped_type rktype

--- a/lib/ir/kosutyped/asttyhelper.ml
+++ b/lib/ir/kosutyped/asttyhelper.ml
@@ -113,7 +113,8 @@ module RType = struct
           { module_path = lmp; parametrics_type = lpt; name = lname },
         RTParametric_identifier
           { module_path = rmp; parametrics_type = rpt; name = rname } ) ->
-        if lmp <> rmp || lname <> rname || Util.are_diff_lenght lpt rpt then
+        if lmp <> rmp || lname <> rname || Util.Ulist.are_diff_length lpt rpt
+        then
           ()
         else
           List.iter2 (fun l r -> update_generics map l r ()) lpt rpt
@@ -133,7 +134,8 @@ module RType = struct
         ),
         RTParametric_identifier
           { module_path = rmp; parametrics_type = rpt; name = rname } ) ->
-        if lmp <> rmp || lname <> rname || Util.are_diff_lenght lpt rpt then
+        if lmp <> rmp || lname <> rname || Util.Ulist.are_diff_length lpt rpt
+        then
           lhs
         else
           RTParametric_identifier
@@ -151,7 +153,7 @@ module RType = struct
     | RTUnknow, rtk | rtk, RTUnknow ->
         rtk
     | (RTTuple rkts as rkt), RTTuple lkts ->
-        if Util.are_diff_lenght rkts lkts then
+        if Util.Ulist.are_diff_length rkts lkts then
           rkt
         else
           RTTuple (List.map2 restrict_rktype rkts lkts)
@@ -702,8 +704,7 @@ module Function = struct
                if function_decl.generics |> List.mem name then
                  let () =
                    Hashtbl.replace generic_table name
-                     ( function_decl.generics
-                       |> Util.ListHelper.index_of (( = ) name),
+                     ( function_decl.generics |> Util.Ulist.index_of (( = ) name),
                        kt
                      )
                  in
@@ -743,7 +744,7 @@ module Function = struct
     | RTPointer lhs, RTPointer rhs ->
         is_type_compatible_hashgen generic_table lhs rhs function_decl
     | RTTuple lhs, RTTuple rhs ->
-        Util.are_same_lenght lhs rhs
+        Util.Ulist.are_same_length lhs rhs
         && List.for_all2
              (fun lkt rkt ->
                is_type_compatible_hashgen generic_table lkt rkt function_decl

--- a/lib/util/checksum.ml
+++ b/lib/util/checksum.ml
@@ -1,7 +1,7 @@
 (**********************************************************************************************)
 (*                                                                                            *)
 (* This file is part of Kosu                                                                  *)
-(* Copyright (C) 2022 Yves Ndiaye                                                             *)
+(* Copyright (C) 2023 Yves Ndiaye                                                             *)
 (*                                                                                            *)
 (* Kosu is free software: you can redistribute it and/or modify it under the terms            *)
 (* of the GNU General Public License as published by the Free Software Foundation,            *)
@@ -15,49 +15,4 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-module Args = Args
-module Occurence = Occurence
-module Io = Io
-module PkgConfig = PkgConfig
-module Checksum = Checksum
-module Ulist = Ulist
-
-type stringlit_label = SLit of string
-type floatlit_label = FLit of string
-type coordinate = { line : int; column : int }
-
-let () = Callback.register "c_caml_list_length" List.length
-let couple a b = (a, b)
-
-let is_what_file ~extension filename =
-  filename |> Filename.extension |> ( = ) extension
-
-let is_object_file = is_what_file ~extension:".o"
-
-let is_asm_file filename =
-  filename |> Filename.extension |> String.lowercase_ascii |> ( = ) ".s"
-
-let rec string_of_chars_aux count result char =
-  if count <= 0 then
-    result
-  else
-    string_of_chars_aux (count - 1) (Printf.sprintf "%c%s" char result) char
-
-let string_of_chars count = string_of_chars_aux count ""
-
-let string_of_module_path path =
-  if path = "" then
-    ""
-  else
-    Printf.sprintf "%s::" path
-
-let dummy_generic_map generic_names parametrics_types =
-  let list_len = parametrics_types |> List.length in
-  let dummy_list = List.init list_len (fun _ -> ()) in
-  let dummy_parametrics = List.combine dummy_list parametrics_types in
-  let generics_mapped = List.combine generic_names dummy_parametrics in
-  Hashtbl.of_seq (generics_mapped |> List.to_seq)
-
-module Operator = struct
-  let ( >? ) o v = Option.value ~default:v o
-end
+let checksum bytes = Digest.bytes bytes

--- a/lib/util/io.ml
+++ b/lib/util/io.ml
@@ -1,7 +1,7 @@
 (**********************************************************************************************)
 (*                                                                                            *)
 (* This file is part of Kosu                                                                  *)
-(* Copyright (C) 2022 Yves Ndiaye                                                             *)
+(* Copyright (C) 2023 Yves Ndiaye                                                             *)
 (*                                                                                            *)
 (* Kosu is free software: you can redistribute it and/or modify it under the terms            *)
 (* of the GNU General Public License as published by the Free Software Foundation,            *)
@@ -15,49 +15,4 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-module Args = Args
-module Occurence = Occurence
-module Io = Io
-module PkgConfig = PkgConfig
-module Checksum = Checksum
-module Ulist = Ulist
-
-type stringlit_label = SLit of string
-type floatlit_label = FLit of string
-type coordinate = { line : int; column : int }
-
-let () = Callback.register "c_caml_list_length" List.length
-let couple a b = (a, b)
-
-let is_what_file ~extension filename =
-  filename |> Filename.extension |> ( = ) extension
-
-let is_object_file = is_what_file ~extension:".o"
-
-let is_asm_file filename =
-  filename |> Filename.extension |> String.lowercase_ascii |> ( = ) ".s"
-
-let rec string_of_chars_aux count result char =
-  if count <= 0 then
-    result
-  else
-    string_of_chars_aux (count - 1) (Printf.sprintf "%c%s" char result) char
-
-let string_of_chars count = string_of_chars_aux count ""
-
-let string_of_module_path path =
-  if path = "" then
-    ""
-  else
-    Printf.sprintf "%s::" path
-
-let dummy_generic_map generic_names parametrics_types =
-  let list_len = parametrics_types |> List.length in
-  let dummy_list = List.init list_len (fun _ -> ()) in
-  let dummy_parametrics = List.combine dummy_list parametrics_types in
-  let generics_mapped = List.combine generic_names dummy_parametrics in
-  Hashtbl.of_seq (generics_mapped |> List.to_seq)
-
-module Operator = struct
-  let ( >? ) o v = Option.value ~default:v o
-end
+let read_file ch () = really_input_string ch (in_channel_length ch)

--- a/lib/util/occurence.ml
+++ b/lib/util/occurence.ml
@@ -1,7 +1,7 @@
 (**********************************************************************************************)
 (*                                                                                            *)
 (* This file is part of Kosu                                                                  *)
-(* Copyright (C) 2022 Yves Ndiaye                                                             *)
+(* Copyright (C) 2023 Yves Ndiaye                                                             *)
 (*                                                                                            *)
 (* Kosu is free software: you can redistribute it and/or modify it under the terms            *)
 (* of the GNU General Public License as published by the Free Software Foundation,            *)
@@ -15,49 +15,35 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-module Args = Args
-module Occurence = Occurence
-module Io = Io
-module PkgConfig = PkgConfig
-module Checksum = Checksum
-module Ulist = Ulist
+type 'a occurence = Empty | One of 'a | Multiple of 'a list
 
-type stringlit_label = SLit of string
-type floatlit_label = FLit of string
-type coordinate = { line : int; column : int }
+exception Too_Many_Occurence
+exception No_Occurence
 
-let () = Callback.register "c_caml_list_length" List.length
-let couple a b = (a, b)
+let is_one = function One _ -> true | _ -> false
 
-let is_what_file ~extension filename =
-  filename |> Filename.extension |> ( = ) extension
+let one = function
+  | Empty ->
+      raise No_Occurence
+  | Multiple _ ->
+      raise Too_Many_Occurence
+  | One f ->
+      f
 
-let is_object_file = is_what_file ~extension:".o"
+let find_map_occurence predicate list =
+  match list |> List.filter_map predicate with
+  | [] ->
+      Empty
+  | [ t ] ->
+      One t
+  | t :: q ->
+      Multiple (t :: q)
 
-let is_asm_file filename =
-  filename |> Filename.extension |> String.lowercase_ascii |> ( = ) ".s"
-
-let rec string_of_chars_aux count result char =
-  if count <= 0 then
-    result
-  else
-    string_of_chars_aux (count - 1) (Printf.sprintf "%c%s" char result) char
-
-let string_of_chars count = string_of_chars_aux count ""
-
-let string_of_module_path path =
-  if path = "" then
-    ""
-  else
-    Printf.sprintf "%s::" path
-
-let dummy_generic_map generic_names parametrics_types =
-  let list_len = parametrics_types |> List.length in
-  let dummy_list = List.init list_len (fun _ -> ()) in
-  let dummy_parametrics = List.combine dummy_list parametrics_types in
-  let generics_mapped = List.combine generic_names dummy_parametrics in
-  Hashtbl.of_seq (generics_mapped |> List.to_seq)
-
-module Operator = struct
-  let ( >? ) o v = Option.value ~default:v o
-end
+let find_occurence predicate list =
+  match list |> List.find_all predicate with
+  | [] ->
+      Empty
+  | [ t ] ->
+      One t
+  | t :: q ->
+      Multiple (t :: q)

--- a/lib/util/pkgConfig.ml
+++ b/lib/util/pkgConfig.ml
@@ -1,0 +1,153 @@
+(**********************************************************************************************)
+(*                                                                                            *)
+(* This file is part of Kosu                                                                  *)
+(* Copyright (C) 2023 Yves Ndiaye                                                             *)
+(*                                                                                            *)
+(* Kosu is free software: you can redistribute it and/or modify it under the terms            *)
+(* of the GNU General Public License as published by the Free Software Foundation,            *)
+(* either version 3 of the License, or (at your option) any later version.                    *)
+(*                                                                                            *)
+(* Kosu is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;          *)
+(* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR           *)
+(* PURPOSE.  See the GNU General Public License for more details.                             *)
+(* You should have received a copy of the GNU General Public License along with Kosu.         *)
+(* If not, see <http://www.gnu.org/licenses/>.                                                *)
+(*                                                                                            *)
+(**********************************************************************************************)
+
+module StringSet = Set.Make (String)
+
+type pkg_config = {
+  include_path : StringSet.t;
+  libs_path : StringSet.t;
+  linked_libs : StringSet.t;
+  others : StringSet.t;
+}
+
+let add_include_path path pkg_config =
+  { pkg_config with include_path = StringSet.add path pkg_config.include_path }
+
+let add_libs_path path pkg_config =
+  { pkg_config with libs_path = StringSet.add path pkg_config.libs_path }
+
+let add_linked_libs libs pkg_config =
+  { pkg_config with linked_libs = StringSet.add libs pkg_config.linked_libs }
+
+let add_others option pkg_config =
+  { pkg_config with others = StringSet.add option pkg_config.others }
+
+let read_file ch () = really_input_string ch (in_channel_length ch)
+let cmd = "pkg-config"
+
+let create ?(include_path = StringSet.empty) ?(libs_path = StringSet.empty)
+    ?(linked_libs = StringSet.empty) others =
+  { include_path; libs_path; linked_libs; others }
+
+let empty = create StringSet.empty
+
+let parse_single pkg_config option =
+  if String.length option < 2 then
+    add_others option pkg_config
+  else
+    match String.sub option 0 2 with
+    | "-L" ->
+        add_libs_path option pkg_config
+    | "-I" ->
+        add_include_path option pkg_config
+    | "-l" ->
+        add_libs_path option pkg_config
+    | _ ->
+        add_others option pkg_config
+
+let parse pkg_output =
+  pkg_output |> String.split_on_char ' ' |> List.map String.trim
+  |> List.fold_left parse_single empty
+
+let of_command_opt ~verbose ?(cflags = false) ?(clibs = true) ~libname () =
+  let command =
+    Printf.sprintf "%s %s %s %s" cmd
+      ( if cflags then
+          "--cflags"
+        else
+          ""
+      )
+      ( if clibs then
+          "--libs"
+        else
+          ""
+      )
+      libname
+  in
+  let () =
+    if verbose then
+      print_endline command
+  in
+
+  let in_channel = Unix.open_process_in command in
+  let content = In_channel.input_all in_channel in
+  let process_status = Unix.close_process_in in_channel in
+  match process_status with
+  | WEXITED code when code = 0 ->
+      content |> parse |> Option.some
+  | _ ->
+      None
+
+let of_command ~verbose ?(cflags = false) ?(clibs = true) ~libname () =
+  let command =
+    Printf.sprintf "%s %s %s %s" cmd
+      ( if cflags then
+          "--cflags"
+        else
+          ""
+      )
+      ( if clibs then
+          "--libs"
+        else
+          ""
+      )
+      libname
+  in
+  let () =
+    if verbose then
+      print_endline command
+  in
+
+  let in_channel = Unix.open_process_in command in
+  let content = In_channel.input_all in_channel in
+  let process_status = Unix.close_process_in in_channel in
+  match process_status with
+  | WEXITED code when code = 0 ->
+      content |> parse
+  | WEXITED code | WSIGNALED code | WSTOPPED code ->
+      let () = prerr_endline content in
+      exit code
+
+let union pkg1 pkg2 =
+  let union = StringSet.union in
+  {
+    include_path = union pkg1.include_path pkg2.include_path;
+    libs_path = union pkg1.libs_path pkg2.libs_path;
+    linked_libs = union pkg1.linked_libs pkg2.linked_libs;
+    others = union pkg1.others pkg2.others;
+  }
+
+let mix pkg_config =
+  pkg_config.others
+  |> StringSet.union pkg_config.include_path
+  |> StringSet.union pkg_config.libs_path
+  |> StringSet.union pkg_config.linked_libs
+
+let cc_flags_format pkg_config =
+  let union = StringSet.union in
+  pkg_config.others
+  |> union pkg_config.include_path
+  |> StringSet.elements |> String.concat " " |> Printf.sprintf "%s"
+
+let linker_flags_format pkg_config =
+  let union = StringSet.union in
+  pkg_config.linked_libs |> union pkg_config.libs_path |> StringSet.elements
+  |> String.concat " " |> Printf.sprintf "%s"
+
+let to_string pkg_config =
+  pkg_config |> mix |> StringSet.elements |> String.concat " "
+  |> Printf.sprintf "%s"

--- a/lib/util/ulist.ml
+++ b/lib/util/ulist.ml
@@ -1,0 +1,129 @@
+(**********************************************************************************************)
+(*                                                                                            *)
+(* This file is part of Kyoumi                                                                *)
+(* Copyright (C) 2023 Yves Ndiaye                                                             *)
+(*                                                                                            *)
+(* Kyoumi is free software: you can redistribute it and/or modify it under the terms          *)
+(* of the GNU General Public License as published by the Free Software Foundation,            *)
+(* either version 3 of the License, or (at your option) any later version.                    *)
+(*                                                                                            *)
+(* Kyoumi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;        *)
+(* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR           *)
+(* PURPOSE.  See the GNU General Public License for more details.                             *)
+(* You should have received a copy of the GNU General Public License along with Kyoumi.       *)
+(* If not, see <http://www.gnu.org/licenses/>.                                                *)
+(*                                                                                            *)
+(**********************************************************************************************)
+
+let rec index_of_aux f index = function
+  | [] ->
+      raise Not_found
+  | t :: q ->
+      if f t then
+        index
+      else
+        index_of_aux f (index + 1) q
+
+let index_of f = index_of_aux f 0
+let head_opt = function [] -> None | t :: _ -> Some t
+
+let rec duplicate_aux hashmap list =
+  match list with
+  | [] ->
+      hashmap |> Hashtbl.to_seq |> List.of_seq
+      |> List.filter_map (fun (key, value) ->
+             if value > 1 then
+               Some key
+             else
+               None
+         )
+  | t :: q ->
+      let () =
+        match Hashtbl.find_opt hashmap t with
+        | Some value ->
+            Hashtbl.replace hashmap t (value + 1)
+        | None ->
+            Hashtbl.add hashmap t 1
+      in
+      duplicate_aux hashmap q
+
+let duplicate l = duplicate_aux (Hashtbl.create (l |> List.length)) l
+
+let rec duplic_aux cmp ~acc ~list =
+  match list with
+  | [] ->
+      acc
+  | t :: q ->
+      let duplicate, no_duplicated = q |> List.partition (cmp t) in
+      let duplicate =
+        if duplicate = [] then
+          acc
+        else
+          (t :: duplicate) :: acc
+      in
+      duplic_aux cmp ~acc:duplicate ~list:no_duplicated
+
+let duplicated cmp list = duplic_aux cmp ~acc:[] ~list
+
+let inner_count list =
+  List.fold_left (fun acc (_, value) -> acc + (value |> List.length)) 0 list
+
+let rec combine_safe lhs rhs =
+  match (lhs, rhs) with
+  | [], _ | _, [] ->
+      []
+  | t1 :: q1, t2 :: q2 ->
+      (t1, t2) :: combine_safe q1 q2
+
+let rec diff base ~remains =
+  match (base, remains) with
+  | _, [] ->
+      []
+  | [], l ->
+      l
+  | _ :: q1, _ :: q2 ->
+      diff q1 ~remains:q2
+
+let rec ldiff fcompare lhs rhs =
+  match (lhs, rhs) with
+  | [], e | e, [] ->
+      e
+  | x1 :: xs1, x2 :: xs2 -> (
+      match fcompare x1 x2 with
+      | 0 ->
+          ldiff fcompare xs1 xs2
+      | _ ->
+          x2 :: ldiff fcompare xs1 xs2
+    )
+
+let rec popn n = function
+  | [] ->
+      []
+  | _ :: q as list ->
+      if n = 0 then
+        list
+      else
+        popn (n - 1) q
+
+let rec shrink ~atlength list =
+  match (atlength, list) with
+  | n, _ when n < 0 ->
+      invalid_arg "Negative number"
+  | 0, _ ->
+      []
+  | _, [] ->
+      []
+  | n, t :: q ->
+      t :: shrink ~atlength:(n - 1) q
+
+let are_same_length l1 l2 = 0 = List.compare_lengths l1 l2
+let are_diff_length l1 l2 = not @@ are_same_length l1 l2
+
+let rec map_ok f = function
+  | [] ->
+      Result.ok []
+  | t :: q ->
+      let ( let* ) = Result.bind in
+      let* res = f t in
+      let* list = map_ok f q in
+      Result.ok @@ (res :: list)


### PR DESCRIPTION
## Done

  - Remove **--ccol** option
      - Now (C, Assembly, Objects) files can be passed as positional arguments
  - Add **--framework** option
  - Add **--check-only** option
      - Equivalent of cc ```-fsyntax-only``` option
  - Fix opaque type mistaken with simple identifier type